### PR TITLE
Add version IRI to `taxslim-disjoint-over-in-taxon.owl` and not merge taxslim.owl import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ ncbitaxon.ttl
 odk.sh
 subsets/taxslim-disjoint-over-in-taxon.owl
 subsets/taxslim.owl
+subsets/current_taxslim-disjoint.owl
+subsets/taxslim-disjoint-diff.md

--- a/subsets/Makefile
+++ b/subsets/Makefile
@@ -5,7 +5,7 @@ TODAY ?=                    $(shell date +%Y-%m-%d)
 VERSION=                    $(TODAY)
 ONTBASE= http://purl.obolibrary.org/obo/ncbitaxon
  
-all: taxslim taxslim-disjoint-over-in-taxon.owl 
+all: taxslim taxslim-disjoint-over-in-taxon.owl taxslim-disjoint-diff.md
 
 taxslim: taxon-subset-ids.txt
 	OWLTOOLS_MEMORY=8G owltools ../ncbitaxon.obo --create-slim --output-owl taxslim.owl --output-obo taxslim.obo --old-obo taxslim.obo --iri $(ONTBASE)/subsets/taxslim.owl --ids taxon-subset-ids.txt
@@ -15,8 +15,13 @@ taxslim: taxon-subset-ids.txt
 taxslim-disjoint-over-in-taxon.owl: taxslim
 	owltools taxslim.owl --create-taxon-disjoint-over-in-taxon --root NCBITaxon:1
 	robot query --input taxslim.owl --format ttl --query add-taxon-disjoints.ru $@.tmp.ttl
-	robot merge --input $@ --input $@.tmp.ttl --output $@.tmp.owl && mv $@.tmp.owl $@
+	robot merge --input $@ --input $@.tmp.ttl --collapse-import-closure false \
+	      annotate -V $(ONTBASE)/releases/$(VERSION)/subsets/$@ --annotation owl:versionInfo $(VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@
 	rm $@.tmp.ttl
+
+taxslim-disjoint-diff.md: taxslim-disjoint-over-in-taxon.owl
+	wget http://purl.obolibrary.org/obo/ncbitaxon/subsets/$< -O current_taxslim-disjoint.owl
+	robot diff --labels true --left current_taxslim-disjoint.owl --right $< -f markdown -o $@
 
 ## The following should not be run as part of CI job.
 ## Admin for this project should run and check in results.


### PR DESCRIPTION
Fixes #83

Also added in the Makefile a goal to generate a diff for the `taxslim-disjoint-over-in-taxon.owl` to catch easily changes when running releases.