### PR TITLE
Use OMO for synonym type predicates

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -237,15 +237,16 @@ oboInOwl:{predicate} a owl:AnnotationProperty
             )
 
         for label, (parent, omo_curie) in predicates.items():
+            parent = parent.replace("oboInOwl", "oio")
             if omo_curie is not None:
                 output.write(dedent(f"""
                     {omo_curie} a owl:AnnotationProperty ;
                         rdfs:label "{label}"^^xsd:string ;
+                        oboInOwl:hasScope "{parent}"^^xsd:string ;
                         rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
                 """))
             else:
                 predicate = label_to_id(label)
-                parent = parent.replace("oboInOwl", "oio")
                 output.write(dedent(f"""
                     ncbitaxon:{predicate} a owl:AnnotationProperty ;
                         rdfs:label "{label}"^^xsd:string ;

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -42,6 +42,11 @@ predicates = {
     "teleomorph": related_synonym,
 }
 
+predicate_to_omo = {
+    "misspelling": "OMO:0003006",
+    "misnomer": "OMO:0003007",
+}
+
 ranks = [
     "class",
     "cohort",
@@ -111,7 +116,10 @@ def convert_synonyms(tax_id, synonyms):
         if name_class in predicates:
             synonym = escape_literal(synonym)
             predicate = predicates[name_class]
-            synonym_type = label_to_id(name_class)
+            if text in predicate_to_omo:
+                synonym_type_curie = predicate_to_omo[text]
+            else:
+                synonym_type_curie = "ncbitaxon:" + label_to_id(name_class)
             output.append(
                 f"""
 NCBITaxon:{tax_id} {predicate} "{synonym}"^^xsd:string .
@@ -119,7 +127,7 @@ NCBITaxon:{tax_id} {predicate} "{synonym}"^^xsd:string .
 ; owl:annotatedSource NCBITaxon:{tax_id}
 ; owl:annotatedProperty {predicate}
 ; owl:annotatedTarget "{synonym}"^^xsd:string
-; oboInOwl:hasSynonymType ncbitaxon:{synonym_type}
+; oboInOwl:hasSynonymType {synonym_type_curie}
 ] ."""
             )
     return output

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -28,21 +28,21 @@ broad_synonym = "oboInOwl:hasBroadSynonym"
 # See OMO properties at
 # https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv
 predicates = {
-    "acronym": (broad_synonym, "OMO:0003000"),  # abbreviation
-    "anamorph": (related_synonym, None),
-    "blast name": (related_synonym, None),
-    "common name": (exact_synonym, "OMO:0003003"),  # layperson synonym
-    "equivalent name": (exact_synonym, None),
-    "genbank acronym": (broad_synonym, None),
-    "genbank anamorph": (related_synonym, None),
-    "genbank common name": (exact_synonym, None),
-    "genbank synonym": (related_synonym, None),
-    "in-part": (related_synonym, None),
-    "misnomer": (related_synonym, "OMO:0003007"),  # misnomer
-    "misspelling": (related_synonym, "OMO:0003006"),  # misspelling
-    "synonym": (related_synonym, None),
-    "scientific name": (exact_synonym, None),
-    "teleomorph": (related_synonym, None),
+    "acronym": (broad_synonym, "OMO:0003000", "abbreviation"),
+    "anamorph": (related_synonym, None, None),
+    "blast name": (related_synonym, None, None),
+    "common name": (exact_synonym, "OMO:0003003", "layperson synonym"), 
+    "equivalent name": (exact_synonym, None, None),
+    "genbank acronym": (broad_synonym, None, None),
+    "genbank anamorph": (related_synonym, None, None),
+    "genbank common name": (exact_synonym, None, None),
+    "genbank synonym": (related_synonym, None, None),
+    "in-part": (related_synonym, None, None),
+    "misnomer": (related_synonym, "OMO:0003007", "misnomer"),
+    "misspelling": (related_synonym, "OMO:0003006", "misspelling"),
+    "synonym": (related_synonym, None, None),
+    "scientific name": (exact_synonym, None, None),
+    "teleomorph": (related_synonym, None, None),
 }
 
 
@@ -114,7 +114,7 @@ def convert_synonyms(tax_id, synonyms):
     for synonym, unique, name_class in synonyms:
         if name_class in predicates:
             synonym = escape_literal(synonym)
-            predicate, synonym_type_curie = predicates[name_class]
+            predicate, synonym_type_curie, _ = predicates[name_class]
             if synonym_type_curie is None:
                 synonym_type_curie = "ncbitaxon:" + label_to_id(name_class)
             output.append(
@@ -236,9 +236,10 @@ oboInOwl:{predicate} a owl:AnnotationProperty
 """
             )
 
-        for label, (parent, curie) in predicates.items():
+        for ad_hoc_label, (parent, curie, label) in predicates.items():
             parent = parent.replace("oboInOwl", "oio")
-            if curie is None:
+            if curie is None and label is None:
+                label = ad_hoc_label
                 curie = f"ncbitaxon:{label_to_id(label)}"
             output.write(dedent(f"""
                 {curie} a owl:AnnotationProperty ;

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -236,23 +236,16 @@ oboInOwl:{predicate} a owl:AnnotationProperty
 """
             )
 
-        for label, (parent, omo_curie) in predicates.items():
+        for label, (parent, curie) in predicates.items():
             parent = parent.replace("oboInOwl", "oio")
-            if omo_curie is not None:
-                output.write(dedent(f"""
-                    {omo_curie} a owl:AnnotationProperty ;
-                        rdfs:label "{label}"^^xsd:string ;
-                        oboInOwl:hasScope "{parent}"^^xsd:string ;
-                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
-                """))
-            else:
-                predicate = label_to_id(label)
-                output.write(dedent(f"""
-                    ncbitaxon:{predicate} a owl:AnnotationProperty ;
-                        rdfs:label "{label}"^^xsd:string ;
-                        oboInOwl:hasScope "{parent}"^^xsd:string ;
-                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
-                """))
+            if curie is None:
+                curie = f"ncbitaxon:{label_to_id(label)}"
+            output.write(dedent(f"""
+                {curie} a owl:AnnotationProperty ;
+                    rdfs:label "{label}"^^xsd:string ;
+                    oboInOwl:hasScope "{parent}"^^xsd:string ;
+                    rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+            """))
 
         with zipfile.ZipFile(taxdmp_path) as taxdmp:
             with taxdmp.open("names.dmp") as dmp:

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -27,7 +27,7 @@ broad_synonym = "oboInOwl:hasBroadSynonym"
 # See OMO properties at
 # https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv
 predicates = {
-    "acronym": (broad_synonym, "OMO:0003000", "abbreviation"),
+    "acronym": (broad_synonym, "OMO:0003012", "acronym"),
     "anamorph": (related_synonym, None, None),
     "blast name": (related_synonym, None, None),
     "common name": (exact_synonym, "OMO:0003003", "layperson synonym"),

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -246,8 +246,7 @@ oboInOwl:{predicate} a owl:AnnotationProperty
                     f"""
             {omo_predicate} a owl:AnnotationProperty ;
                         rdfs:label "{omo_label}"^^xsd:string .
-
-            """
+                    """
                 )
             )
 

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -6,6 +6,7 @@ import zipfile
 
 from collections import defaultdict
 from datetime import date
+from textwrap import dedent
 
 oboInOwl = {
     "SynonymTypeProperty": "synonym_type_property",
@@ -116,8 +117,8 @@ def convert_synonyms(tax_id, synonyms):
         if name_class in predicates:
             synonym = escape_literal(synonym)
             predicate = predicates[name_class]
-            if text in predicate_to_omo:
-                synonym_type_curie = predicate_to_omo[text]
+            if name_class in predicate_to_omo:
+                synonym_type_curie = predicate_to_omo[name_class]
             else:
                 synonym_type_curie = "ncbitaxon:" + label_to_id(name_class)
             output.append(
@@ -203,6 +204,7 @@ def convert(taxdmp_path, output_path, taxa=None):
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix OMO: <http://purl.obolibrary.org/obo/OMO_> .
 @prefix terms: <http://purl.org/dc/terms/> .
 @prefix ncbitaxon: <http://purl.obolibrary.org/obo/ncbitaxon#> .
 @prefix NCBITaxon: <http://purl.obolibrary.org/obo/NCBITaxon_> .
@@ -237,6 +239,18 @@ oboInOwl:{predicate} a owl:AnnotationProperty
 .
 """
             )
+
+        for omo_label, omo_predicate in predicate_to_omo.items():
+            output.write(
+                dedent(
+                    f"""
+            {omo_predicate} a owl:AnnotationProperty ;
+                        rdfs:label "{omo_label}"^^xsd:string .
+
+            """
+                )
+            )
+
         for label, parent in predicates.items():
             predicate = label_to_id(label)
             parent = parent.replace("oboInOwl", "oio")

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -236,30 +236,22 @@ oboInOwl:{predicate} a owl:AnnotationProperty
 """
             )
 
-        for omo_label, omo_predicate in predicate_to_omo.items():
-            output.write(
-                dedent(
-                    f"""
-            {omo_predicate} a owl:AnnotationProperty ;
-                        rdfs:label "{omo_label}"^^xsd:string .
-                    """
-                )
-            )
-
         for label, (parent, omo_curie) in predicates.items():
             if omo_curie is not None:
-                continue
-            predicate = label_to_id(label)
-            parent = parent.replace("oboInOwl", "oio")
-            output.write(
-                f"""
-ncbitaxon:{predicate} a owl:AnnotationProperty
-; rdfs:label "{label}"^^xsd:string
-; oboInOwl:hasScope "{parent}"^^xsd:string
-; rdfs:subPropertyOf oboInOwl:SynonymTypeProperty
-.
-"""
-            )
+                output.write(dedent(f"""
+                    {omo_curie} a owl:AnnotationProperty ;
+                        rdfs:label "{label}"^^xsd:string ;
+                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+                """))
+            else:
+                predicate = label_to_id(label)
+                parent = parent.replace("oboInOwl", "oio")
+                output.write(dedent(f"""
+                    ncbitaxon:{predicate} a owl:AnnotationProperty ;
+                        rdfs:label "{label}"^^xsd:string ;
+                        oboInOwl:hasScope "{parent}"^^xsd:string ;
+                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+                """))
 
         with zipfile.ZipFile(taxdmp_path) as taxdmp:
             with taxdmp.open("names.dmp") as dmp:

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -31,7 +31,7 @@ predicates = {
     "acronym": (broad_synonym, "OMO:0003000", "abbreviation"),
     "anamorph": (related_synonym, None, None),
     "blast name": (related_synonym, None, None),
-    "common name": (exact_synonym, "OMO:0003003", "layperson synonym"), 
+    "common name": (exact_synonym, "OMO:0003003", "layperson synonym"),
     "equivalent name": (exact_synonym, None, None),
     "genbank acronym": (broad_synonym, None, None),
     "genbank anamorph": (related_synonym, None, None),
@@ -249,14 +249,18 @@ oboInOwl:{predicate} a owl:AnnotationProperty
         for ad_hoc_label, (parent, curie, label) in predicates.items():
             parent = parent.replace("oboInOwl", "oio")
             if curie is None and label is None:
-                label = ad_hoc_label
-                curie = f"ncbitaxon:{label_to_id(label)}"
-            output.write(dedent(f"""
-                {curie} a owl:AnnotationProperty ;
-                    rdfs:label "{label}"^^xsd:string ;
-                    oboInOwl:hasScope "{parent}"^^xsd:string ;
-                    rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
-            """))
+                output.write(dedent(f"""
+                    ncbitaxon:{label_to_id(ad_hoc_label)} a owl:AnnotationProperty ;
+                        rdfs:label "{ad_hoc_label}"^^xsd:string ;
+                        oboInOwl:hasScope "{parent}"^^xsd:string ;
+                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+                """))
+            else:
+                output.write(dedent(f"""
+                    {curie} a owl:AnnotationProperty ;
+                        rdfs:label "{label}"^^xsd:string ;
+                        rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+                """))
 
         with zipfile.ZipFile(taxdmp_path) as taxdmp:
             with taxdmp.open("names.dmp") as dmp:

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -25,28 +25,26 @@ exact_synonym = "oboInOwl:hasExactSynonym"
 related_synonym = "oboInOwl:hasRelatedSynonym"
 broad_synonym = "oboInOwl:hasBroadSynonym"
 
+# See OMO properties at
+# https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv
 predicates = {
-    "acronym": broad_synonym,
-    "anamorph": related_synonym,
-    "blast name": related_synonym,
-    "common name": exact_synonym,
-    "equivalent name": exact_synonym,
-    "genbank acronym": broad_synonym,
-    "genbank anamorph": related_synonym,
-    "genbank common name": exact_synonym,
-    "genbank synonym": related_synonym,
-    "in-part": related_synonym,
-    "misnomer": related_synonym,
-    "misspelling": related_synonym,
-    "synonym": related_synonym,
-    "scientific name": exact_synonym,
-    "teleomorph": related_synonym,
+    "acronym": (broad_synonym, "OMO:0003000"),  # abbreviation
+    "anamorph": (related_synonym, None),
+    "blast name": (related_synonym, None),
+    "common name": (exact_synonym, "OMO:0003003"),  # layperson synonym
+    "equivalent name": (exact_synonym, None),
+    "genbank acronym": (broad_synonym, None),
+    "genbank anamorph": (related_synonym, None),
+    "genbank common name": (exact_synonym, None),
+    "genbank synonym": (related_synonym, None),
+    "in-part": (related_synonym, None),
+    "misnomer": (related_synonym, "OMO:0003007"),  # misnomer
+    "misspelling": (related_synonym, "OMO:0003006"),  # misspelling
+    "synonym": (related_synonym, None),
+    "scientific name": (exact_synonym, None),
+    "teleomorph": (related_synonym, None),
 }
 
-predicate_to_omo = {
-    "misspelling": "OMO:0003006",
-    "misnomer": "OMO:0003007",
-}
 
 ranks = [
     "class",
@@ -116,10 +114,8 @@ def convert_synonyms(tax_id, synonyms):
     for synonym, unique, name_class in synonyms:
         if name_class in predicates:
             synonym = escape_literal(synonym)
-            predicate = predicates[name_class]
-            if name_class in predicate_to_omo:
-                synonym_type_curie = predicate_to_omo[name_class]
-            else:
+            predicate, synonym_type_curie = predicates[name_class]
+            if synonym_type_curie is None:
                 synonym_type_curie = "ncbitaxon:" + label_to_id(name_class)
             output.append(
                 f"""
@@ -250,7 +246,9 @@ oboInOwl:{predicate} a owl:AnnotationProperty
                 )
             )
 
-        for label, parent in predicates.items():
+        for label, (parent, omo_curie) in predicates.items():
+            if omo_curie is not None:
+                continue
             predicate = label_to_id(label)
             parent = parent.replace("oboInOwl", "oio")
             output.write(


### PR DESCRIPTION
Closes #87 

This PR updates the RDF generation to use OMO terms, when available. It extends the `predicates` configuration dictionary at the top so that new OMO terms can be added in as they are minted. Currently, this PR switches 4 terms to using OMO:

| Existing IRI | New OMO IRI |
|--------------|--------------|
| http://purl.obolibrary.org/obo/ncbitaxon#acronym | http://purl.obolibrary.org/obo/OMO_0003012 |
| http://purl.obolibrary.org/obo/ncbitaxon#common_name | http://purl.obolibrary.org/obo/OMO_0003003 |
| http://purl.obolibrary.org/obo/ncbitaxon#misnomer | http://purl.obolibrary.org/obo/OMO_0003007 |
| http://purl.obolibrary.org/obo/ncbitaxon#misspelling | http://purl.obolibrary.org/obo/OMO_0003006 |

There will have to be more detailed follow-up discussion if we want to complete the coverage of OMO on these synonyms.