### PR TITLE
Add missing ranks

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -76,6 +76,16 @@ ranks = [
     "superphylum",
     "tribe",
     "varietas",
+    "strain",
+    "serogroup",
+    "biotype",
+    "clade",
+    "forma specialis",
+    "isolate",
+    "serotype",
+    "genotype",
+    "morph",
+    "pathogroup",
 ]
 
 nodes_fields = [


### PR DESCRIPTION
Closes #89.

This PR adds ranks that were missing. It also makes the logging a bit more manageable by only printing one is missing the first time, then at the end giving a count summary.