### PR TITLE
Improve logging on missing ranks

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -3,8 +3,7 @@
 import argparse
 import io
 import zipfile
-
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import date
 
 oboInOwl = {
@@ -94,6 +93,8 @@ nodes_fields = [
     "comments",  # free-text comments and citations
 ]
 
+UNRECOGNIZED_RANKS = Counter()
+
 
 def escape_literal(text):
     return text.replace('"', '\\"')
@@ -141,7 +142,9 @@ def convert_node(node, label, merged, synonyms, citations):
     rank = node["rank"]
     if rank and rank != "" and rank != "no rank":
         if rank not in ranks:
-            print(f"WARN Unrecognized rank '{rank}'")
+            if rank not in UNRECOGNIZED_RANKS:
+                print(f"unrecognized rank: '{rank}'")
+            UNRECOGNIZED_RANKS[rank] += 1
         rank = label_to_id(rank)
         # WARN: This is a special case for backward compatibility
         if rank in ["species_group", "species_subgroup"]:
@@ -311,6 +314,8 @@ ncbitaxon:{predicate} a owl:AnnotationProperty
                     )
                     output.write(result)
 
+            print("Summary of unrecognized ranks:")
+            print(UNRECOGNIZED_RANKS)
             # TODO: delnodes
 
         output.write(


### PR DESCRIPTION
This PR de-duplicates logging of missing ranks, then gives a summary at the end using a `Counter`.

Here is what I ran locally to check this works:

```
$ make
python3 src/ncbitaxon.py build/taxdmp.zip ncbitaxon.ttl
unrecognized rank: 'strain'
unrecognized rank: 'serogroup'
unrecognized rank: 'biotype'
unrecognized rank: 'clade'
unrecognized rank: 'forma specialis'
unrecognized rank: 'isolate'
unrecognized rank: 'serotype'
unrecognized rank: 'genotype'
unrecognized rank: 'morph'
unrecognized rank: 'pathogroup'
Summary of unrecognized ranks:
Counter({'strain': 45990, 'isolate': 1333, 'serotype': 1237, 'clade': 956, 'forma specialis': 750, 'serogroup': 151, 'genotype': 22, 'biotype': 17, 'morph': 12, 'pathogroup': 5})
```

> **Warning**
> If you run this code after merging #90, there will be no missing ranks and therefore it will not log anything. If you want to test it, you can remove any members of the `ranks` list defined in `/src/ncbitaxon.py`