### PR TITLE
Add proper version and version IRI to taxslim.obo

### DIFF
--- a/subsets/Makefile
+++ b/subsets/Makefile
@@ -10,6 +10,7 @@ all: taxslim taxslim-disjoint-over-in-taxon.owl taxslim-disjoint-diff.md
 taxslim: taxon-subset-ids.txt
 	OWLTOOLS_MEMORY=8G owltools ../ncbitaxon.obo --create-slim --output-owl taxslim.owl --output-obo taxslim.obo --old-obo taxslim.obo --iri $(ONTBASE)/subsets/taxslim.owl --ids taxon-subset-ids.txt
 	robot annotate -i taxslim.owl --ontology-iri $(ONTBASE)/subsets/taxslim.owl annotate -V $(ONTBASE)/releases/$(VERSION)/subsets/taxslim.owl --annotation owl:versionInfo $(VERSION) -o taxslim.owl
+	robot annotate -i taxslim.obo --ontology-iri $(ONTBASE)/subsets/taxslim.obo annotate -V $(ONTBASE)/releases/$(VERSION)/subsets/taxslim.obo --annotation owl:versionInfo $(VERSION) -o taxslim.obo
 	robot convert -i taxslim.owl -f json -o taxslim.json
 
 taxslim-disjoint-over-in-taxon.owl: taxslim


### PR DESCRIPTION
Fixes #38 

I tried to generate only owl file from the owltools, then convert the owl to obo, but somehow we need to output obo with param --old-obo, otherwise it removes many classes. So, I used the same robot annotation command as in the owl file.

There's already version IRI in the taxslim.json because it's converted from taxslim.owl.

Here's the output in the taxslim.obo

```
format-version: 1.2
data-version: ncbitaxon/releases/2024-06-06/subsets/taxslim.obo
...
ontology: ncbitaxon/subsets/taxslim.obo
property_value: owl:versionInfo "2024-06-06" xsd:string
```