### PR TITLE
Demonstrate using TAXRANK for ranks and properties

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -97,6 +97,10 @@ ranks: dict[str, str] = {
     "acellular root": "TAXRANK:9000001",  # https://github.com/phenoscape/taxrank/pull/11
     "cellular root": "TAXRANK:9000002",  # https://github.com/phenoscape/taxrank/pull/11
 }
+pseudo_ranks = {
+    "acellular root",
+    "cellular root",
+}
 
 nodes_fields = [
     "tax_id",  # node id in GenBank taxonomy database
@@ -399,6 +403,10 @@ TAXRANK:0000000 a owl:Class ;
     rdfs:label "taxonomic_rank"^^xsd:string ;
     oboInOwl:hasOBONamespace "taxonomic_rank"^^xsd:string .
 
+TAXRANK:9000000 a owl:Class ;
+    rdfs:label "pseudorank"^^xsd:string ;
+    oboInOwl:hasOBONamespace "taxonomic_rank"^^xsd:string .
+
 """
         )
         for label, rank_curie in ranks.items():
@@ -418,11 +426,12 @@ TAXRANK:0000000 a owl:Class ;
 """
             )
 
+            parent_taxrank_id = "9000000" if label in pseudo_ranks else "0000000"
             output.write(
                 dedent(f"""\
                     {rank_curie} a owl:Class ; 
                         rdfs:label "{label}"^^xsd:string ; 
-                        rdfs:subClassOf TAXRANK:0000000 ;
+                        rdfs:subClassOf TAXRANK:{parent_taxrank_id} ;
                         oboInOwl:hasOBONamespace "taxonomic_rank"^^xsd:string .
 
                 """)

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -164,21 +164,19 @@ def convert_node(node, label, merged, synonyms, citations):
         output.append(f"; rdfs:subClassOf NCBITaxon:{parent_tax_id}")
 
     rank = node["rank"]
-        rank_curie = ranks.get(rank)
-        if not rank_curie:
     if rank and rank != "" and rank != "no rank":
+        if rank not in ranks:
             if rank not in UNRECOGNIZED_RANKS:
                 print(f"unrecognized rank: '{rank}'")
             UNRECOGNIZED_RANKS[rank] += 1
         else:
             RECOGNIZED_RANKS[rank] += 1
-            output.append(f"; TAXRANK:1000000 {rank_curie}")
+            output.append(f"; TAXRANK:1000000 {ranks[rank]}")
 
         # Keep track of examples of each rank for making tables later
         if rank not in RANK_EXAMPLES:
             RANK_EXAMPLES[rank] = f"NCBITaxon:{tax_id}", label
 
-    if rank and rank != "" and rank != "no rank":
         rank = label_to_id(rank)
         # WARN: This is a special case for backward compatibility
         if rank in ["species_group", "species_subgroup"]:
@@ -366,7 +364,7 @@ oboInOwl:{predicate} a owl:AnnotationProperty
                     )
                     output.write(result)
 
-            print("\nSummary of unrecognized ranks:\n")
+            print("Summary of unrecognized ranks:")
             print(UNRECOGNIZED_RANKS)
 
             try:

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -91,6 +91,11 @@ ranks: dict[str, str] = {
     "morph": "TAXRANK:0001009",
     "pathogroup": "TAXRANK:0001011",
     "no rank": "TAXRANK:0000060",
+    "domain": "TAXRANK:0000037",  # see https://github.com/phenoscape/taxrank/pull/10
+    "realm": "TAXRANK:0001013",  # see https://github.com/phenoscape/taxrank/pull/10
+    "subvariety": "TAXRANK:0000051",  # see https://github.com/phenoscape/taxrank/pull/10
+    "acellular root": "TAXRANK:9000001",  # https://github.com/phenoscape/taxrank/pull/11
+    "cellular root": "TAXRANK:9000002",  # https://github.com/phenoscape/taxrank/pull/11
 }
 
 nodes_fields = [

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -171,7 +171,7 @@ def convert_node(node, label, merged, synonyms, citations):
     if rank and rank != "" and rank != "no rank":
         if rank not in ranks:
             if rank not in UNRECOGNIZED_RANKS:
-                print(f"unrecognized rank: '{rank}'")
+                print(f"unrecognized rank: '{rank}', which e.g. appears in NCBITaxon:{tax_id} ({label})")
             UNRECOGNIZED_RANKS[rank] += 1
         else:
             RECOGNIZED_RANKS[rank] += 1

--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -90,7 +90,7 @@ ranks: dict[str, str] = {
     "genotype": "TAXRANK:0001007",
     "morph": "TAXRANK:0001009",
     "pathogroup": "TAXRANK:0001011",
-    "no rank": "TAXRANK:0000060",
+    # "no rank": "TAXRANK:0000060",
     "domain": "TAXRANK:0000037",  # see https://github.com/phenoscape/taxrank/pull/10
     "realm": "TAXRANK:0001013",  # see https://github.com/phenoscape/taxrank/pull/10
     "subvariety": "TAXRANK:0000051",  # see https://github.com/phenoscape/taxrank/pull/10
@@ -164,9 +164,9 @@ def convert_node(node, label, merged, synonyms, citations):
         output.append(f"; rdfs:subClassOf NCBITaxon:{parent_tax_id}")
 
     rank = node["rank"]
-    if rank:
         rank_curie = ranks.get(rank)
         if not rank_curie:
+    if rank and rank != "" and rank != "no rank":
             if rank not in UNRECOGNIZED_RANKS:
                 print(f"unrecognized rank: '{rank}'")
             UNRECOGNIZED_RANKS[rank] += 1


### PR DESCRIPTION
Closes #96, closes #97

This PR does the following (updated Feb 19, 2025):

1. Adds triples connecting NCBITaxon terms to TAXRANK terms using the TAXRANK:100000 (has rank) relation. This duplicates, in parallel, the existing ad-hoc `ncbitaxon:has_rank` relations that point to ad-hoc rank terms in the `NCBITaxon:` namespace
2. Explicitly handles the `no rank` rank
3. Adds deprecation notice to the predicate `ncbitaxon:has_rank`, removes logical axioms, updates its name, and adds a replaced-by notice pointing to TAXRANK:100000
4. Adds a deprecation notice to all ad-hoc NCBITaxon ranks with appropriate replaced-by notices pointing to TAXRANK terms

## Related Work

This PR depends on https://github.com/phenoscape/taxrank/pull/5, where I added the remaining 12 ranks that weren't already represented. That PR was merged and released on November 28<sup>th</sup>, 2024. Related: that PR included adding a tax rank for "strain", which was the point of discussion also in #107.

This PR also depends on https://github.com/phenoscape/taxrank/pull/10 and https://github.com/phenoscape/taxrank/pull/11, where I added 5 more ranks that weren't represented. Those PRs were merged on September 24<sup>th</sup>, 2025.

