### PR TITLE
Remove obsolete node conversion on merged terms

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -311,8 +311,6 @@ oboInOwl:{predicate} a owl:AnnotationProperty
                 for line in io.TextIOWrapper(dmp):
                     old_tax_id, new_tax_id, _ = split_line(line)
                     merged[new_tax_id].append(old_tax_id)
-                    result = convert_obsolete_node(old_tax_id, new_tax_id)
-                    output.write(result)
 
             with taxdmp.open("citations.dmp") as dmp:
                 for line in io.TextIOWrapper(dmp):


### PR DESCRIPTION
Related to #125

This removes the explicitely creation of the obsolete terms.

~~They are already being created on the OWL version, without the label "obsolete".~~

On the OBO Format, this is not available, only via the `alt_id`.

I tested a release and everything looks good.