### PR TITLE
Add missing ranks

### DIFF
--- a/src/ncbitaxon.py
+++ b/src/ncbitaxon.py
@@ -89,6 +89,11 @@ ranks = [
     "genotype",
     "morph",
     "pathogroup",
+    "domain",
+    "realm",
+    "subvariety",
+    "acellular root",
+    "cellular root",
 ]
 
 nodes_fields = [
@@ -158,7 +163,7 @@ def convert_node(node, label, merged, synonyms, citations):
     if rank and rank != "" and rank != "no rank":
         if rank not in ranks:
             if rank not in UNRECOGNIZED_RANKS:
-                print(f"unrecognized rank: '{rank}'")
+                print(f"unrecognized rank: '{rank}', which e.g. appears in NCBITaxon:{tax_id} ({label})")
             UNRECOGNIZED_RANKS[rank] += 1
         rank = label_to_id(rank)
         # WARN: This is a special case for backward compatibility


### PR DESCRIPTION
There are now five new ranks appearing in the NCBI taxonomy database that have not been added to the `ranks` list in the conversion script:

1. domain
2. realm
3. subvariety
4. acellular root
5. cellular root

These new ranks are used very sparingly. Here is the exhaustive list of where they appear:

1. 'domain' appeared in NCBITaxon:2 (Bacteria)
1. 'domain' appeared in NCBITaxon:2157 (Archaea)
1. 'domain' appeared in NCBITaxon:2759 (Eukaryota)
1. 'acellular root' appeared in NCBITaxon:10239 (Viruses)
1. 'cellular root' appeared in NCBITaxon:131567 (cellular organisms)
1. 'realm' appeared in NCBITaxon:2559587 (Riboviria)
1. 'realm' appeared in NCBITaxon:2731341 (Duplodnaviria)
1. 'realm' appeared in NCBITaxon:2731342 (Monodnaviria)
1. 'realm' appeared in NCBITaxon:2732004 (Varidnaviria)
1. 'realm' appeared in NCBITaxon:2840022 (Adnaviria)
1. 'realm' appeared in NCBITaxon:2842242 (Ribozyviria)
1. 'subvariety' appeared in NCBITaxon:3162245 (Helichrysum dracaenifolium subvar. oblanceolatum)
1. 'realm' appeared in NCBITaxon:3412574 (Singelaviria)

This PR adds those five taxranks to the `ranks` list, so the script is aware of them and correctly serializes taxrank annotations for these thirteen records.

## Related work

We added these five terms to TAXRANK in:

- [x] https://github.com/phenoscape/taxrank/pull/11
- [x] https://github.com/phenoscape/taxrank/pull/10